### PR TITLE
Add example of Auto Command for Vim in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ NOTE: Create this directory if it doesn't already exist.
 
 You can enable syntax highlighing in one of the following ways:
 
-. Put a Vim _autocmd_ in your Vim configuration file
+. Put a Vim _autocmd_ in your Vim configuration file `autocmd BufRead,BufNewFile *.adoc set syntax=asciidoc`
 . Execute the Vim command `:set syntax=asciidoc`
 . Add the following line to the end of you AsciiDoc source files:
 


### PR DESCRIPTION
An example of the actual command needed to make it work.
If the command is not correct, please let me know. It took me a lot of hunting around just to get that syntax highlighting working for adoc documents. This example might help people deal with the problem swiftly (since this repo almost always appears in search results).

Hope it helps.